### PR TITLE
updated to install EPEL to make lighttpd available

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,8 @@ LABEL io.k8s.description="Platform for serving static HTML filesi built with str
       io.openshift.tags="builder,html,strapdown,lighttpd"
 
 # Install the required software, namely Lighttpd and
-RUN yum install -y lighttpd  && \
+RUN yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm && \
+    yum install -y lighttpd  && \
     # clean yum cache files, as they are not needed and will only make the image bigger in the end
     yum clean all -y
 


### PR DESCRIPTION
The build of the image was failing for me both in my local OpenShift instance and running ```docker build .```

I have updated the Dockerfile to now install EPEL which makes the lighttpd RPM available.

Thanks!

Ashley